### PR TITLE
Missing winning token for diagonal wins on connect4 tests

### DIFF
--- a/technical-fundamentals/coding/__tests__/connect4.test.mjs
+++ b/technical-fundamentals/coding/__tests__/connect4.test.mjs
@@ -35,14 +35,14 @@ describe("Connect4", () => {
 
   it("it should detect diagonal winning", () => {
     const c4 = new Connect4({ width: 10, height: 10 });
-    const plays = [1, 2, 2, 3, 4, 3, 3, 4, 5, 4];
+    const plays = [1, 2, 2, 3, 4, 3, 3, 4, 5, 4, 4];
     plays.forEach((p) => c4.play(p));
     expect(c4.winner()).toEqual(PLAYER_ONE);
   });
 
   it("it should detect diagonal winning", () => {
     const c4 = new Connect4({ width: 10, height: 10 });
-    const plays = [1, 2, 2, 3, 4, 3, 3, 4, 5, 4].reverse();
+    const plays = [1, 2, 2, 3, 4, 3, 3, 4, 5, 4, 4].reverse();
     plays.forEach((p) => c4.play(p));
     expect(c4.winner()).toEqual(PLAYER_ONE);
   });


### PR DESCRIPTION
## Changes
Added the missing winning token for diagonal test cases

Current status:
|   |   |   |   |   |   |   |   |   |
|---|---|---|---|---|---|---|---|---|
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   | X | 0 |   |   |   |   |   |   
|   | X | 0 | 0 |   |   |   |   |   |   
| X | 0 | 0 | X | X |   |   |   |   |   

New Status:
|   |   |   |   |   |   |   |   |   |
|---|---|---|---|---|---|---|---|---|
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   |   |   |   |   |   |   |   
|   |   |   | X |   |   |   |   |   |   
|   |   | X | 0 |   |   |   |   |   |   
|   | X | 0 | 0 |   |   |   |   |   |   
| X | 0 | 0 | X | X |   |   |   |   |   
